### PR TITLE
New regions 2016

### DIFF
--- a/emencia/django/french_zones/fixtures/2016_evolution_data.xml
+++ b/emencia/django/french_zones/fixtures/2016_evolution_data.xml
@@ -1,0 +1,644 @@
+<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object pk="42" model="french_zones.region">
+    <field type="CharField" name="name">Alsace</field>
+  </object>
+  <object pk="72" model="french_zones.region">
+    <field type="CharField" name="name">Aquitaine</field>
+  </object>
+  <object pk="83" model="french_zones.region">
+    <field type="CharField" name="name">Auvergne</field>
+  </object>
+  <object pk="25" model="french_zones.region">
+    <field type="CharField" name="name">Basse-Normandie</field>
+  </object>
+  <object pk="26" model="french_zones.region">
+    <field type="CharField" name="name">Bourgogne</field>
+  </object>
+  <object pk="53" model="french_zones.region">
+    <field type="CharField" name="name">Bretagne</field>
+  </object>
+  <object pk="24" model="french_zones.region">
+    <field type="CharField" name="name">Centre</field>
+  </object>
+  <object pk="21" model="french_zones.region">
+    <field type="CharField" name="name">Champagne-Ardenne</field>
+  </object>
+  <object pk="94" model="french_zones.region">
+    <field type="CharField" name="name">Corse</field>
+  </object>
+  <object pk="43" model="french_zones.region">
+    <field type="CharField" name="name">Franche-Comté</field>
+  </object>
+  <object pk="01" model="french_zones.region">
+    <field type="CharField" name="name">Guadeloupe</field>
+  </object>
+  <object pk="03" model="french_zones.region">
+    <field type="CharField" name="name">Guyane</field>
+  </object>
+  <object pk="23" model="french_zones.region">
+    <field type="CharField" name="name">Haute-Normandie</field>
+  </object>
+  <object pk="11" model="french_zones.region">
+    <field type="CharField" name="name">Ile-de-France</field>
+  </object>
+  <object pk="04" model="french_zones.region">
+    <field type="CharField" name="name">La Réunion</field>
+  </object>
+  <object pk="91" model="french_zones.region">
+    <field type="CharField" name="name">Languedoc-Rousillon</field>
+  </object>
+  <object pk="74" model="french_zones.region">
+    <field type="CharField" name="name">Limousin</field>
+  </object>
+  <object pk="41" model="french_zones.region">
+    <field type="CharField" name="name">Lorraine</field>
+  </object>
+  <object pk="02" model="french_zones.region">
+    <field type="CharField" name="name">Martinique</field>
+  </object>
+  <object pk="73" model="french_zones.region">
+    <field type="CharField" name="name">Midi-Pyrénées</field>
+  </object>
+  <object pk="31" model="french_zones.region">
+    <field type="CharField" name="name">Nord-Pas-de-Calais</field>
+  </object>
+  <object pk="52" model="french_zones.region">
+    <field type="CharField" name="name">Pays de la Loire</field>
+  </object>
+  <object pk="22" model="french_zones.region">
+    <field type="CharField" name="name">Picardie</field>
+  </object>
+  <object pk="54" model="french_zones.region">
+    <field type="CharField" name="name">Poitou-Charentes</field>
+  </object>
+  <object pk="93" model="french_zones.region">
+    <field type="CharField" name="name">Provence-Alpes-Côte d'Azur</field>
+  </object>
+  <object pk="82" model="french_zones.region">
+    <field type="CharField" name="name">Rhône-Alpes</field>
+  </object>
+
+
+  <object pk="44" model="french_zones.region2016">
+    <field type="CharField" name="name">Alsace-Champagne-Ardenne-Lorraine</field>
+  </object>
+  <object pk="75" model="french_zones.region2016">
+    <field type="CharField" name="name">Aquitaine-Limousin-Poitou-Charentes</field>
+  </object>
+  <object pk="84" model="french_zones.region2016">
+    <field type="CharField" name="name">Auvergne-Rhône-Alpes</field>
+  </object>
+  <object pk="27" model="french_zones.region2016">
+    <field type="CharField" name="name">Bourgogne-Franche-Comté</field>
+  </object>
+  <object pk="53" model="french_zones.region2016">
+    <field type="CharField" name="name">Bretagne</field>
+  </object>
+  <object pk="24" model="french_zones.region2016">
+    <field type="CharField" name="name">Centre-Val de Loire</field>
+  </object>
+  <object pk="94" model="french_zones.region2016">
+    <field type="CharField" name="name">Corse</field>
+  </object>
+  <object pk="11" model="french_zones.region2016">
+    <field type="CharField" name="name">Île-de-France</field>
+  </object>
+  <object pk="76" model="french_zones.region2016">
+    <field type="CharField" name="name">Languedoc-Roussillon-Midi-Pyrénées</field>
+  </object>
+  <object pk="32" model="french_zones.region2016">
+    <field type="CharField" name="name">Nord-Pas-de-Calais-Picardie</field>
+  </object>
+  <object pk="28" model="french_zones.region2016">
+    <field type="CharField" name="name">Normandie</field>
+  </object>
+  <object pk="52" model="french_zones.region2016">
+    <field type="CharField" name="name">Pays de la Loire</field>
+  </object>
+  <object pk="93" model="french_zones.region2016">
+    <field type="CharField" name="name">Provence-Alpes-Côte d'Azur</field>
+  </object>
+  <object pk="01" model="french_zones.region2016">
+    <field type="CharField" name="name">Guadeloupe</field>
+  </object>
+  <object pk="02" model="french_zones.region2016">
+    <field type="CharField" name="name">Martinique</field>
+  </object>
+  <object pk="03" model="french_zones.region2016">
+    <field type="CharField" name="name">Guyane</field>
+  </object>
+  <object pk="04" model="french_zones.region2016">
+    <field type="CharField" name="name">La Réunion</field>
+  </object>
+  <object pk="06" model="french_zones.region2016">
+    <field type="CharField" name="name">Mayotte</field>
+  </object>
+
+
+  <object pk="01" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">82</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Ain</field>
+  </object>
+  <object pk="02" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">22</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">32</field>
+    <field type="CharField" name="name">Aisne</field>
+  </object>
+  <object pk="03" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">83</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Allier</field>
+  </object>
+  <object pk="04" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">93</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">93</field>
+    <field type="CharField" name="name">Alpes-de-Haute-Provence</field>
+  </object>
+  <object pk="05" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">93</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">93</field>
+    <field type="CharField" name="name">Hautes-Alpes</field>
+  </object>
+  <object pk="06" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">93</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">93</field>
+    <field type="CharField" name="name">Alpes-Maritimes</field>
+  </object>
+  <object pk="07" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">82</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Ardèche</field>
+  </object>
+  <object pk="08" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">21</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Ardennes</field>
+  </object>
+  <object pk="09" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">73</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Ariège</field>
+  </object>
+  <object pk="10" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">21</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Aube</field>
+  </object>
+  <object pk="11" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">91</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Aude</field>
+  </object>
+  <object pk="12" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">73</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Aveyron</field>
+  </object>
+  <object pk="13" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">93</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">93</field>
+    <field type="CharField" name="name">Bouches-du-Rhône</field>
+  </object>
+  <object pk="14" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">25</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">28</field>
+    <field type="CharField" name="name">Calvados</field>
+  </object>
+  <object pk="15" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">83</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Cantal</field>
+  </object>
+  <object pk="16" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">54</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Charente</field>
+  </object>
+  <object pk="17" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">54</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Charente-Maritime</field>
+  </object>
+  <object pk="18" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">24</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">24</field>
+    <field type="CharField" name="name">Cher</field>
+  </object>
+  <object pk="19" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">74</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Corrèze</field>
+  </object>
+  <object pk="21" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">26</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">27</field>
+    <field type="CharField" name="name">Côte-d'Or</field>
+  </object>
+  <object pk="22" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">53</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">53</field>
+    <field type="CharField" name="name">Côtes-d'Armor</field>
+  </object>
+  <object pk="23" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">74</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Creuse</field>
+  </object>
+  <object pk="24" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">72</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Dordogne</field>
+  </object>
+  <object pk="25" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">43</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">27</field>
+    <field type="CharField" name="name">Doubs</field>
+  </object>
+  <object pk="26" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">82</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Drôme</field>
+  </object>
+  <object pk="27" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">23</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">28</field>
+    <field type="CharField" name="name">Eure</field>
+  </object>
+  <object pk="28" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">24</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">24</field>
+    <field type="CharField" name="name">Eure-et-Loire</field>
+  </object>
+  <object pk="29" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">53</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">53</field>
+    <field type="CharField" name="name">Finistère</field>
+  </object>
+  <object pk="2A" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">94</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">94</field>
+    <field type="CharField" name="name">Corse-du-Sud</field>
+  </object>
+  <object pk="2B" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">94</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">94</field>
+    <field type="CharField" name="name">Haute-Corse</field>
+  </object>
+  <object pk="30" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">91</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Gard</field>
+  </object>
+  <object pk="31" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">73</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Haute-Garonne</field>
+  </object>
+  <object pk="32" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">73</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Gers</field>
+  </object>
+  <object pk="33" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">72</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Gironde</field>
+  </object>
+  <object pk="34" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">91</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Hérault</field>
+  </object>
+  <object pk="35" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">53</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">53</field>
+    <field type="CharField" name="name">Ille-et-Vilaine</field>
+  </object>
+  <object pk="36" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">24</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">24</field>
+    <field type="CharField" name="name">Indre</field>
+  </object>
+  <object pk="37" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">24</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">24</field>
+    <field type="CharField" name="name">Indre-et-Loire</field>
+  </object>
+  <object pk="38" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">82</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Isère</field>
+  </object>
+  <object pk="39" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">43</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">27</field>
+    <field type="CharField" name="name">Jura</field>
+  </object>
+  <object pk="40" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">72</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Landes</field>
+  </object>
+  <object pk="41" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">24</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">24</field>
+    <field type="CharField" name="name">Loir-et-Cher</field>
+  </object>
+  <object pk="42" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">82</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Loire</field>
+  </object>
+  <object pk="43" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">83</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Haute-Loire</field>
+  </object>
+  <object pk="44" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">52</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">52</field>
+    <field type="CharField" name="name">Loire-Atlantique</field>
+  </object>
+  <object pk="45" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">24</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">24</field>
+    <field type="CharField" name="name">Loiret</field>
+  </object>
+  <object pk="46" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">73</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Lot</field>
+  </object>
+  <object pk="47" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">72</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Lot-et-Garonne</field>
+  </object>
+  <object pk="48" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">91</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Lozère</field>
+  </object>
+  <object pk="49" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">52</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">52</field>
+    <field type="CharField" name="name">Maine-et-Loire</field>
+  </object>
+  <object pk="50" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">25</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">28</field>
+    <field type="CharField" name="name">Manche</field>
+  </object>
+  <object pk="51" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">21</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Marne</field>
+  </object>
+  <object pk="52" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">21</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Haute-Marne</field>
+  </object>
+  <object pk="53" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">52</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">52</field>
+    <field type="CharField" name="name">Mayenne</field>
+  </object>
+  <object pk="54" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">41</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Meurthe-et-Moselle</field>
+  </object>
+  <object pk="55" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">41</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Meuse</field>
+  </object>
+  <object pk="56" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">53</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">53</field>
+    <field type="CharField" name="name">Morbihan</field>
+  </object>
+  <object pk="57" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">41</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Moselle</field>
+  </object>
+  <object pk="58" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">26</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">27</field>
+    <field type="CharField" name="name">Nièvre</field>
+  </object>
+  <object pk="59" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">31</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">32</field>
+    <field type="CharField" name="name">Nord</field>
+  </object>
+  <object pk="60" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">22</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">32</field>
+    <field type="CharField" name="name">Oise</field>
+  </object>
+  <object pk="61" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">25</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">28</field>
+    <field type="CharField" name="name">Orne</field>
+  </object>
+  <object pk="62" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">31</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">32</field>
+    <field type="CharField" name="name">Pas-de-Calais</field>
+  </object>
+  <object pk="63" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">83</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Puy-de-Dôme</field>
+  </object>
+  <object pk="64" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">72</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Pyrénées-Atlantiques</field>
+  </object>
+  <object pk="65" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">73</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Hautes-Pyrénées</field>
+  </object>
+  <object pk="66" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">91</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Pyrénées-Orientales</field>
+  </object>
+  <object pk="67" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">42</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Bas-Rhin</field>
+  </object>
+  <object pk="68" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">42</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Haut-Rhin</field>
+  </object>
+  <object pk="69" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">82</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Rhône</field>
+  </object>
+  <object pk="70" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">43</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">27</field>
+    <field type="CharField" name="name">Haute-Saône</field>
+  </object>
+  <object pk="71" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">26</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">27</field>
+    <field type="CharField" name="name">Saône-et-Loire</field>
+  </object>
+  <object pk="72" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">52</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">52</field>
+    <field type="CharField" name="name">Sarthe</field>
+  </object>
+  <object pk="73" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">82</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Savoie</field>
+  </object>
+  <object pk="74" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">82</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">84</field>
+    <field type="CharField" name="name">Haute-Savoie</field>
+  </object>
+  <object pk="75" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">11</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">11</field>
+    <field type="CharField" name="name">Paris</field>
+  </object>
+  <object pk="76" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">23</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">28</field>
+    <field type="CharField" name="name">Seine-Maritime</field>
+  </object>
+  <object pk="77" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">11</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">11</field>
+    <field type="CharField" name="name">Seine-et-Marne</field>
+  </object>
+  <object pk="78" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">11</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">11</field>
+    <field type="CharField" name="name">Yvenlines</field>
+  </object>
+  <object pk="79" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">54</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Deux-Sèvres</field>
+  </object>
+  <object pk="80" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">22</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">32</field>
+    <field type="CharField" name="name">Somme</field>
+  </object>
+  <object pk="81" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">73</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Tarn</field>
+  </object>
+  <object pk="82" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">73</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">76</field>
+    <field type="CharField" name="name">Tarn-et-Garonne</field>
+  </object>
+  <object pk="83" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">93</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">93</field>
+    <field type="CharField" name="name">Var</field>
+  </object>
+  <object pk="84" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">93</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">93</field>
+    <field type="CharField" name="name">Vaucluse</field>
+  </object>
+  <object pk="85" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">52</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">52</field>
+    <field type="CharField" name="name">Vendée</field>
+  </object>
+  <object pk="86" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">54</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Vienne</field>
+  </object>
+  <object pk="87" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">74</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">75</field>
+    <field type="CharField" name="name">Haute-Vienne</field>
+  </object>
+  <object pk="88" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">41</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">44</field>
+    <field type="CharField" name="name">Vosges</field>
+  </object>
+  <object pk="89" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">26</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">27</field>
+    <field type="CharField" name="name">Yonne</field>
+  </object>
+  <object pk="90" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">43</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">27</field>
+    <field type="CharField" name="name">Territoire de Belfort</field>
+  </object>
+  <object pk="91" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">11</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">11</field>
+    <field type="CharField" name="name">Essonne</field>
+  </object>
+  <object pk="92" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">11</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">11</field>
+    <field type="CharField" name="name">Hauts-de-Seine</field>
+  </object>
+  <object pk="93" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">11</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">11</field>
+    <field type="CharField" name="name">Seine-Saint-Denis </field>
+  </object>
+  <object pk="94" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">11</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">11</field>
+    <field type="CharField" name="name">Val-de-Marne</field>
+  </object>
+  <object pk="95" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">11</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">11</field>
+    <field type="CharField" name="name">Val-d'Oise</field>
+  </object>
+  <object pk="971" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">01</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">01</field>
+    <field type="CharField" name="name">Guadeloupe</field>
+  </object>
+  <object pk="972" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">02</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">02</field>
+    <field type="CharField" name="name">Martinique</field>
+  </object>
+  <object pk="973" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">03</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">03</field>
+    <field type="CharField" name="name">Guyane</field>
+  </object>
+  <object pk="974" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">04</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">04</field>
+    <field type="CharField" name="name">La Réunion</field>
+  </object>
+  <object pk="976" model="french_zones.department">
+    <field to="french_zones.region" name="region" rel="ManyToOneRel">04</field>
+    <field to="french_zones.region2016" name="region_2016" rel="ManyToOneRel">04</field>
+    <field type="CharField" name="name">Mayotte</field>
+  </object>
+</django-objects>

--- a/emencia/django/french_zones/migrations/0003_add_region_2016.py
+++ b/emencia/django/french_zones/migrations/0003_add_region_2016.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+from django.utils.text import slugify
+
+from emencia.django.french_zones.models import Region, Department
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        # Create region2016 model
+        # Add region2016 data
+        db.create_table(u'french_zones_region_2016', (
+            ('code', self.gf('django.db.models.fields.CharField')(max_length=2, primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=12)),
+            ('slug', self.gf('django.db.models.fields.SlugField')(max_length=12, blank=True)),
+        ))
+        db.send_create_signal(u'french_zones', ['Region2016'])
+
+        # Add region2016 field to regions
+        db.add_column(
+            u'french_zones_region', 'region_2016',
+            self.gf('django.db.models.fields.related.ForeignKey')(
+                to=orm['french_zones.Region2016'], null=True
+            ),
+            keep_default=False
+        )
+
+        # Add region2016 field to departments
+        db.add_column(
+            u'french_zones_department', 'region_2016',
+            self.gf('django.db.models.fields.related.ForeignKey')(
+                to=orm['french_zones.Region2016'], null=True
+            ),
+            keep_default=False
+        )
+
+    def backwards(self, orm):
+        db.delete_table(u'french_zones_region_2016')
+        db.delete_column(u'french_zones_region', 'region2016_id')
+        db.delete_column(u'french_zones_department', 'region2016_id')
+
+    models = {
+        u'french_zones.department': {
+            'Meta': {'ordering': "('code',)", 'object_name': 'Department'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '3', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['french_zones.Region']"}),
+            'region_2016': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['french_zones.Region2016']", 'null': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '128', 'blank': 'True'})
+        },
+        u'french_zones.region': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Region'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '2', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'region_2016': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['french_zones.Region2016']", 'null': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '128', 'blank': 'True'})
+        },
+        u'french_zones.region2016': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Region2016'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '2', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '128', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['french_zones']

--- a/emencia/django/french_zones/migrations/0004_data_migration_2016.py
+++ b/emencia/django/french_zones/migrations/0004_data_migration_2016.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from south.v2 import SchemaMigration
+from django.core.management import call_command
+from django.utils._os import upath
+
+from os.path import join, dirname
+
+from emencia.django.french_zones.models import Region, Department, Region2016
+from emencia.django import french_zones
+
+
+REGION_TRANSLATION_DICT = {
+    u'01': u'01',
+    u'02': u'02',
+    u'03': u'03',
+    u'04': u'04',
+    u'06': u'06',
+    u'11': u'11',
+    u'21': u'44',
+    u'22': u'32',
+    u'23': u'28',
+    u'24': u'24',
+    u'25': u'28',
+    u'26': u'27',
+    u'31': u'32',
+    u'41': u'44',
+    u'42': u'44',
+    u'43': u'27',
+    u'52': u'52',
+    u'53': u'53',
+    u'54': u'75',
+    u'72': u'75',
+    u'73': u'76',
+    u'74': u'75',
+    u'82': u'84',
+    u'83': u'84',
+    u'91': u'76',
+    u'93': u'93',
+    u'94': u'94',
+}
+
+
+def region_2016_from_region_2015(region_2015):
+    code_2016 = REGION_TRANSLATION_DICT[region_2015.code]
+    region_2016 = Region2016.objects.get(code=code_2016)
+    return region_2016
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Add Region2016 data
+        fixture_file = upath(
+            join(dirname(french_zones.__file__),
+                 "fixtures/2016_evolution_data.xml")
+        )
+        call_command("loaddata", fixture_file)
+
+        # Set region_2016 fields to regions
+        for region in Region.objects.all():
+            region.region_2016 = region_2016_from_region_2015(region)
+            region.save()
+
+        # Set region_2016 fields to departments
+        for department in Department.objects.all():
+            region = department.region
+            department.region_2016 = region.region_2016
+            department.save()
+
+    def backwards(self, orm):
+        pass
+
+
+    models = {
+        u'french_zones.department': {
+            'Meta': {'ordering': "('code',)", 'object_name': 'Department'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '3', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['french_zones.Region']"}),
+            'region_2016': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['french_zones.Region2016']", 'null': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '128', 'blank': 'True'})
+        },
+        u'french_zones.region': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Region'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '2', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'region_2016': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['french_zones.Region2016']", 'null': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '128', 'blank': 'True'})
+        },
+        u'french_zones.region2016': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Region2016'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '2', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '128', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['french_zones']

--- a/emencia/django/french_zones/models.py
+++ b/emencia/django/french_zones/models.py
@@ -2,7 +2,8 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-class Region(models.Model):
+
+class Region2016(models.Model):
     code = models.CharField(_('code INSEE'), max_length=2, primary_key=True)
     name = models.CharField(_('official name'), max_length=128)
     slug = models.SlugField(max_length=128, blank=True)
@@ -14,9 +15,27 @@ class Region(models.Model):
         verbose_name = _('region')
         verbose_name_plural = _('regions')
         ordering = ('name',)
+        db_table = "french_zones_region_2016"
+
+
+class Region(models.Model):
+    code = models.CharField(_('code INSEE'), max_length=2, primary_key=True)
+    name = models.CharField(_('official name'), max_length=128)
+    slug = models.SlugField(max_length=128, blank=True)
+    region_2016 = models.ForeignKey(Region2016, null=True)
+
+    def __unicode__(self):
+        return self.name
+
+    class Meta:
+        verbose_name = _('region')
+        verbose_name_plural = _('regions')
+        ordering = ('name',)
+
 
 class Department(models.Model):
     region = models.ForeignKey(Region, verbose_name=_('region'))
+    region_2016 = models.ForeignKey(Region2016, null=True)
 
     code = models.CharField(_('code'), max_length=3, primary_key=True)
     name = models.CharField(_('official name'), max_length=128)
@@ -29,6 +48,3 @@ class Department(models.Model):
         verbose_name = _('department')
         verbose_name_plural = _('departments')
         ordering = ('code',)
-
-
-

--- a/emencia/django/french_zones/tests.py
+++ b/emencia/django/french_zones/tests.py
@@ -7,6 +7,7 @@ from emencia.django.french_zones.utils import get_region_from_postal_code
 from emencia.django.french_zones.utils import get_region_2016_from_postal_code
 from emencia.django.french_zones.utils import get_department_from_postal_code
 
+
 class UtilsTestCase(TestCase):
 
     def test_get_department_from_postal_code(self):

--- a/emencia/django/french_zones/tests.py
+++ b/emencia/django/french_zones/tests.py
@@ -1,9 +1,10 @@
 """Unit tests for emencia.django.french_zones"""
 from django.test import TestCase
 
-from emencia.django.french_zones.models import Region
+from emencia.django.french_zones.models import Region, Region2016
 from emencia.django.french_zones.models import Department
 from emencia.django.french_zones.utils import get_region_from_postal_code
+from emencia.django.french_zones.utils import get_region_2016_from_postal_code
 from emencia.django.french_zones.utils import get_department_from_postal_code
 
 class UtilsTestCase(TestCase):
@@ -36,3 +37,22 @@ class UtilsTestCase(TestCase):
         self.assertEquals(get_region_from_postal_code('20600'), corse)
         self.assertEquals(get_region_from_postal_code('97105'), guadeloupe)
 
+    def test_get_region2016_from_postal_code(self):
+        self.assertRaises(ValueError, get_region_2016_from_postal_code, '')
+        self.assertRaises(ValueError, get_region_2016_from_postal_code, '1234')
+
+        nord_pas_de_calais_picardie = Region2016.objects.get(pk='32')
+        ile_de_france = Region2016.objects.get(pk='11')
+        corse = Region2016.objects.get(pk='94')
+        guadeloupe = Region2016.objects.get(pk='01')
+        aquitaine_limousin_poitou_charentes = Region2016.objects.get(pk='75')
+
+        self.assertEquals(get_region_2016_from_postal_code('62138'),
+                          nord_pas_de_calais_picardie)
+        self.assertEquals(get_region_2016_from_postal_code('75012'),
+                          ile_de_france)
+        self.assertEquals(get_region_2016_from_postal_code('20600'), corse)
+        self.assertEquals(get_region_2016_from_postal_code('97105'),
+                          guadeloupe)
+        self.assertEquals(get_region_2016_from_postal_code('23001'),
+                          aquitaine_limousin_poitou_charentes)

--- a/emencia/django/french_zones/utils.py
+++ b/emencia/django/french_zones/utils.py
@@ -21,6 +21,6 @@ def get_region_from_postal_code(postal_code):
     """Return the Department model associated to a postal code"""
     return get_department_from_postal_code(postal_code).region
 
-
-
-        
+def get_region_2016_from_postal_code(postal_code):
+    """Return the new 2016 region associated with a postal code"""
+    return get_department_from_postal_code(postal_code).region.region_2016

--- a/emencia/django/french_zones/utils.py
+++ b/emencia/django/french_zones/utils.py
@@ -1,8 +1,8 @@
 """Utils for emencia.django.french_zones"""
 from django.utils.translation import ugettext as _
 
-from emencia.django.french_zones.models import Region
 from emencia.django.french_zones.models import Department
+
 
 def get_department_from_postal_code(postal_code):
     """Return the Region model associated to a postal code"""
@@ -11,10 +11,10 @@ def get_department_from_postal_code(postal_code):
 
     code = postal_code[:2]
     if code == '20':
-        code =  '2A'
+        code = '2A'
     if code == '97':
         code = postal_code[:3]
-    
+
     return Department.objects.get(code=code)
 
 def get_region_from_postal_code(postal_code):


### PR DESCRIPTION
This branch brings in the new 2016 specs, with new regions.
The first commit adds the models and fields related to the new regions:
Instead of "breaking" the models, and reusing Region for the new regions, I'm introducing a new Region2016 model and region_2016 fields. That way, projects already using emencia-django-french_zones won't have weird results if they update this module (like old region maps linked to new regions). The shift to the new 2016 regions should be: update the emencia-django-french_zones dependancy, and then update the project code to use Department.region_2016 or Region.region_2016 instead of previous calls.

The second commit populates the Region2016 model and updates the Region and Department models with new data. 
